### PR TITLE
Default to patch version bump when no commit prefix provided

### DIFF
--- a/build/bin/initbuild.sh
+++ b/build/bin/initbuild.sh
@@ -82,7 +82,8 @@ else
     semver bump ${SEMVER_RELEASE_LEVEL} ${SEMVER_LAST_TAG} > $VERSION_FILE
     echo "Configuring semver for ${SEMVER_RELEASE_LEVEL} bump from ${SEMVER_LAST_TAG} to $(cat $VERSION_FILE)"
   else
-    semver bump build build.$GITHUB_RUN_ID > $VERSION_FILE
+    # Default to a patch revision
+    semver bump patch ${SEMVER_LAST_TAG} > $VERSION_FILE
     echo "Configuring semver for rebuild of ${SEMVER_LAST_TAG}: $(cat $VERSION_FILE)"
   fi
 fi


### PR DESCRIPTION
Apply the same update already delivered to cli and ansible-devops repos so that we can better handle commits missing the expected `[patch|minor|major]` prefix.