### PR TITLE
[minor] install rclone

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,4 @@ Provides:
 - `jq`
 - `yq` v4.35.1
 - `tini` v0.19.0
+- `rclone`

--- a/image/cli-base/Dockerfile
+++ b/image/cli-base/Dockerfile
@@ -28,6 +28,7 @@ RUN umask 0002 && \
     bash /tmp/install/install-helm.sh && \
     bash /tmp/install/install-mongo-tools.sh && \
     bash /tmp/install/install-yq.sh && \
+    bash /tmp/install/install-rclone.sh && \
     rm -rf /tmp/install && \
     rm /opt/app-root/src/.wget-hsts /opt/app-root/src/README.md /opt/app-root/src/LICENSE
 

--- a/image/cli-base/install/install-rclone.sh
+++ b/image/cli-base/install/install-rclone.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Install Rclone CLI
+set -e
+
+curl -O https://downloads.rclone.org/rclone-current-linux-amd64.zip
+unzip rclone-current-linux-amd64.zip
+
+cp ./rclone-*-linux-amd64/rclone /usr/local/bin/
+
+rclone version
+
+rm -rf rclone-*


### PR DESCRIPTION
https://rclone.org/
Rclone (MIT license) is a widely used tool for mange the files on various storage system. We can use this tool to copy files between Pod and s3 object storage, this is a very useful when we want to backup large files from PV to remote COS, for example the MVI image datasets stored in PV. 
By adding this tool to mas cli base image, we can create a OpenShfit Job based on the mas cli image to perform the copying works in this Job. Becuase it is a server to server coping method which is more faster than download files from Pod to local first and then upload files to remote COS.
