### PR TITLE
[minor] Install UBI-9 and ArgoCD and ROSA CLIs for gitops

### DIFF
--- a/.github/workflows/build-cli-base.yml
+++ b/.github/workflows/build-cli-base.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           docker images
           docker login --username "${{ secrets.QUAYIO_USERNAME }}" --password "${{ secrets.QUAYIO_PASSWORD }}" quay.io
-          docker push quay.io/ibmmas/cli:${{ env.DOCKER_TAG }}
+          docker push quay.io/ibmmas/cli-base:${{ env.DOCKER_TAG }}
         # Old version ...
         # uses: redhat-actions/push-to-registry@v2
         # with:

--- a/.github/workflows/build-cli-base.yml
+++ b/.github/workflows/build-cli-base.yml
@@ -34,8 +34,13 @@ jobs:
       # https://github.com/marketplace/actions/push-to-registry
       - name: Push the docker image
         id: push_to_quay
-        uses: redhat-actions/push-to-registry@v2
-        with:
-          tags: quay.io/ibmmas/cli-base:${{ env.DOCKER_TAG }}
-          username: ${{ secrets.QUAYIO_USERNAME }}
-          password: ${{ secrets.QUAYIO_PASSWORD }}
+        run: |
+          docker images
+          docker login --username "${{ secrets.QUAYIO_USERNAME }}" --password "${{ secrets.QUAYIO_PASSWORD }}" quay.io
+          docker push quay.io/ibmmas/cli:${{ env.DOCKER_TAG }}
+        # Old version ...
+        # uses: redhat-actions/push-to-registry@v2
+        # with:
+        #   tags: quay.io/ibmmas/cli-base:${{ env.DOCKER_TAG }}
+        #   username: ${{ secrets.QUAYIO_USERNAME }}
+        #   password: ${{ secrets.QUAYIO_PASSWORD }}

--- a/image/cli-base/Dockerfile
+++ b/image/cli-base/Dockerfile
@@ -28,6 +28,8 @@ RUN umask 0002 && \
     bash /tmp/install/install-helm.sh && \
     bash /tmp/install/install-mongo-tools.sh && \
     bash /tmp/install/install-yq.sh && \
+    bash /tmp/install/install-argocd.sh && \
+    bash /tmp/install/install-rosa.sh && \
     rm -rf /tmp/install && \
     rm /opt/app-root/src/.wget-hsts /opt/app-root/src/README.md /opt/app-root/src/LICENSE
 

--- a/image/cli-base/Dockerfile
+++ b/image/cli-base/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/python-39
+FROM registry.access.redhat.com/ubi9/python-39
 ARG VERSION_LABEL
 # ----- Start as "default" user ----------------------------------------------
 # Running as userId = default

--- a/image/cli-base/install/install-argocd.sh
+++ b/image/cli-base/install/install-argocd.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Install ArgoCD CLI
+set -e
+curl -sSL -o argocd-linux-amd64 https://github.com/argoproj/argo-cd/releases/latest/download/argocd-linux-amd64 && \
+    install -m 555 argocd-linux-amd64 /usr/local/bin/argocd && \
+    rm argocd-linux-amd64

--- a/image/cli-base/install/install-mongo-tools.sh
+++ b/image/cli-base/install/install-mongo-tools.sh
@@ -3,18 +3,18 @@
 # Install Mongo Shell
 set -e
 
-curl "https://downloads.mongodb.com/compass/mongodb-mongosh-shared-openssl11-1.10.5.x86_64.rpm" -o mongodb-mongosh-shared-openssl11-1.10.5.x86_64.rpm
-rpm -i mongodb-mongosh-shared-openssl11-1.10.5.x86_64.rpm
+curl "https://downloads.mongodb.com/compass/mongodb-mongosh-shared-openssl11-2.2.10.x86_64.rpm" -o mongodb-mongosh-shared-openssl11-2.2.10.x86_64.rpm
+rpm -i mongodb-mongosh-shared-openssl11-2.2.10.x86_64.rpm
 
 mongosh --version
-rm mongodb-mongosh-shared-openssl11-1.10.5.x86_64.rpm
+rm mongodb-mongosh-shared-openssl11-2.2.10.x86_64.rpm
 
 # Install Mongo Tools
-curl "https://fastdl.mongodb.org/tools/db/mongodb-database-tools-rhel80-x86_64-100.8.0.tgz" -o mongodb-database-tools-rhel80-x86_64-100.8.0.tgz
-tar xvfz mongodb-database-tools-rhel80-x86_64-100.8.0.tgz
+curl "https://fastdl.mongodb.org/tools/db/mongodb-database-tools-rhel90-x86_64-100.9.5.tgz" -o mongodb-database-tools-rhel90-x86_64-100.9.5.tgz
+tar xvfz mongodb-database-tools-rhel90-x86_64-100.9.5.tgz
 
-mv mongodb-database-tools-rhel80-x86_64-100.8.0/bin/* /usr/local/bin/
-rm -rf mongodb-database-tools-rhel80-x86_64-100.8.0
-rm mongodb-database-tools-rhel80-x86_64-100.8.0.tgz
+mv mongodb-database-tools-rhel90-x86_64-100.9.5/bin/* /usr/local/bin/
+rm -rf mongodb-database-tools-rhel90-x86_64-100.9.5
+rm mongodb-database-tools-rhel90-x86_64-100.9.5.tgz
 
 mongodump --version

--- a/image/cli-base/install/install-mongo-tools.sh
+++ b/image/cli-base/install/install-mongo-tools.sh
@@ -3,11 +3,11 @@
 # Install Mongo Shell
 set -e
 
-curl "https://downloads.mongodb.com/compass/mongodb-mongosh-shared-openssl11-2.2.10.x86_64.rpm" -o mongodb-mongosh-shared-openssl11-2.2.10.x86_64.rpm
-rpm -i mongodb-mongosh-shared-openssl11-2.2.10.x86_64.rpm
+curl "https://downloads.mongodb.com/compass/mongodb-mongosh-shared-openssl3-2.2.9.x86_64.rpm" -o mongodb-mongosh-shared-openssl3-2.2.9.x86_64.rpm
+rpm -i mongodb-mongosh-shared-openssl3-2.2.9.x86_64.rpm
 
 mongosh --version
-rm mongodb-mongosh-shared-openssl11-2.2.10.x86_64.rpm
+rm mongodb-mongosh-shared-openssl3-2.2.9.x86_64.rpm
 
 # Install Mongo Tools
 curl "https://fastdl.mongodb.org/tools/db/mongodb-database-tools-rhel90-x86_64-100.9.5.tgz" -o mongodb-database-tools-rhel90-x86_64-100.9.5.tgz

--- a/image/cli-base/install/install-rosa.sh
+++ b/image/cli-base/install/install-rosa.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Install ROSA Cli
+set -e
+
+wget -q https://mirror.openshift.com/pub/openshift-v4/clients/rosa/latest/rosa-linux.tar.gz
+tar -xzf rosa-linux.tar.gz
+mv rosa /usr/local/bin/
+chmod +x /usr/local/bin/rosa
+chown default:root /usr/local/bin/rosa
+rosa version
+rm -rf rosa-linux.tar.gz

--- a/image/cli-base/install/requirements.txt
+++ b/image/cli-base/install/requirements.txt
@@ -7,3 +7,5 @@ openshift==0.13.2
 jmespath==1.0.1
 click==8.1.7
 prettytable==3.9.0
+jinja-cli==1.2.2
+yq==3.2.2


### PR DESCRIPTION
Updates to use ubi9 version of pyhton39 base image as ubi9 is expected for the `oc` cli.

Now it is at aubi9 then the mongosh needs to use openssl 3 rather than 1.1

Finally, what this PR is raised for:
- Install ArogCD CLI for [gitops](https://github.com/ibm-mas/gitops)
- Install ROSA CLI for [gitops](https://github.com/ibm-mas/gitops)

Tested these changes in a new cli and ran in a non-gitops environment:
![image- 2024-07-02 at 17 04 46](https://github.com/ibm-mas/cli-base/assets/6817894/f0c6c7dc-4206-4004-9383-c098188d2323)
