### PR TITLE
[patch] Remove wrong version of yq

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Provides:
 - `aws`
 - `helm` v3
 - `cloudctl` v3.17.0
-- `mongosh` v1.10.5
-- `mongodump` v100.8.0
+- `mongosh` v2.2.9
+- `mongodump` v100.9.5
 - `oc`
 - `oc mirror`
 - `oc ibm-pak` v1.3.1
@@ -19,3 +19,5 @@ Provides:
 - `yq` v4.35.1
 - `tini` v0.19.0
 - `rclone`
+- `rosa`
+- `argocd`

--- a/image/cli-base/install/requirements.txt
+++ b/image/cli-base/install/requirements.txt
@@ -8,6 +8,5 @@ jmespath==1.0.1
 click==8.1.7
 prettytable==3.9.0
 jinja-cli==1.2.2
-yq==3.2.2
 slackclient==1.3.2
 jira==3.5.2


### PR DESCRIPTION
Removes the yq installed via pip (the https://kislyuk.github.io/yq/ version) so that we only have the expected version which is on the path (https://mikefarah.gitbook.io/yq). The https://kislyuk.github.io/yq version was only used in the `gitops`version of the cli and that will be changed to use the mikefarah version in other PRs.

Also updates the readme with the additional packages installed from the previous PR.

Resolves https://github.com/ibm-mas/cli/issues/1096