### PR TITLE
[minor] Install python module boto3 to support create S3 api key needed for AI Broker

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,3 @@ Provides:
 - `rclone`
 - `ibm-watson-machine-learning`
 - `boto3`
-

--- a/README.md
+++ b/README.md
@@ -19,5 +19,4 @@ Provides:
 - `yq` v4.35.1
 - `tini` v0.19.0
 - `rclone`
-- `ibm-watson-machine-learning`
 - `boto3`

--- a/README.md
+++ b/README.md
@@ -19,3 +19,6 @@ Provides:
 - `yq` v4.35.1
 - `tini` v0.19.0
 - `rclone`
+- `ibm-watson-machine-learning`
+- `boto3`
+

--- a/image/cli-base/install/requirements.txt
+++ b/image/cli-base/install/requirements.txt
@@ -10,4 +10,4 @@ prettytable==3.9.0
 jinja-cli==1.2.2
 slackclient==1.3.2
 jira==3.5.2
-boto3
+boto3==1.34.143

--- a/image/cli-base/install/requirements.txt
+++ b/image/cli-base/install/requirements.txt
@@ -9,3 +9,5 @@ click==8.1.7
 prettytable==3.9.0
 slackclient==1.3.2
 jira==3.5.2
+boto3==1.34.117
+ibm-watson-machine-learning==1.0.357

--- a/image/cli-base/install/requirements.txt
+++ b/image/cli-base/install/requirements.txt
@@ -10,4 +10,3 @@ prettytable==3.9.0
 slackclient==1.3.2
 jira==3.5.2
 boto3
-ibm-watson-machine-learning

--- a/image/cli-base/install/requirements.txt
+++ b/image/cli-base/install/requirements.txt
@@ -9,5 +9,5 @@ click==8.1.7
 prettytable==3.9.0
 slackclient==1.3.2
 jira==3.5.2
-boto3==1.34.117
-ibm-watson-machine-learning==1.0.357
+boto3
+ibm-watson-machine-learning


### PR DESCRIPTION
In existing mas-cli branch which supports aibroker deployment https://github.com/ibm-mas/cli/tree/aibroker we need to create s3 api key - this step is failing bacuse base image does not have installed boto3 image. 

Following error is from cli deployment from `aibroker` branch
```
TASK [ibm.mas_devops.aibroker : Create S3 API Key] *****************************
changed: [localhost] => changed=true 
  rc: 0
  stderr: |-
    Traceback (most recent call last):
      File "/opt/app-root/lib/python3.9/site-packages/ansible_collections/ibm/mas_devops/playbooks/../roles/aibroker/files/create_bucket.py", line 19, in <module>
        import boto3
    ModuleNotFoundError: No module named 'boto3'
  stderr_lines: <omitted>
  stdout: |-
    it is Amazon AWS
    bucketname=
    The credentail of S3 is valid. The bucketname  is created successfully.
    Creating S3 secret in k8s
    secret/aibroker-user----s3-secret created
    Created S3 secret in k8s successfully
  stdout_lines: <omitted>
```

https://boto3.amazonaws.com/v1/documentation/api/latest/index.html