### PR TITLE
[patch] Remove . log folders set by root

### DIFF
--- a/image/cli-base/install/install-ibmpak.sh
+++ b/image/cli-base/install/install-ibmpak.sh
@@ -40,3 +40,5 @@ fi
 
 echo "oc ibm-pak version:"
 oc ibm-pak --version
+
+rm -rf /opt/app-root/src/.ibm-pak

--- a/image/cli-base/install/install-oc.sh
+++ b/image/cli-base/install/install-oc.sh
@@ -43,4 +43,4 @@ rm -f oc-mirror.tar.gz
 echo "oc-mirror version:"
 oc-mirror version --output json
 
-rm -f /opt/app-root/src/.oc-mirror
+rm -f /opt/app-root/src/.oc-mirror.log

--- a/image/cli-base/install/install-oc.sh
+++ b/image/cli-base/install/install-oc.sh
@@ -42,3 +42,5 @@ rm -f oc-mirror.tar.gz
 
 echo "oc-mirror version:"
 oc-mirror version --output json
+
+rm -f /opt/app-root/src/.oc-mirror


### PR DESCRIPTION
When calling the --version on these cli tools, it is creating a . folders for logging under the root user. When this runs in a container that is not root then we get an error saying the log file can't be written too.