### PR TITLE
[minor] install jinjanator

### DIFF
--- a/image/cli-base/install/requirements.txt
+++ b/image/cli-base/install/requirements.txt
@@ -8,6 +8,7 @@ jmespath==1.0.1
 click==8.1.7
 prettytable==3.9.0
 jinja-cli==1.2.2
+jinjanator==25.1.0
 slackclient==1.3.2
 jira==3.5.2
 boto3==1.34.143


### PR DESCRIPTION
MASCORE-5642

* Install `jinjanator` Python package which supports Jinja's extension mechanism, allowing custom template filters to be added to Jinja. Custom filters are not supported by the current package`jinja-cli`, nor is the package maintained (last update was [4 years ago](https://github.com/cykerway/jinja-cli)).
* The intention is to use `jinjanator` in https://github.com/ibm-mas/cli for rendering templates, allowing ugly Jinja code such as [this](https://github.com/ibm-mas/cli/blob/master/image/cli/mascli/templates/gitops/appset-configs/cluster/group-sync-operator.yaml.j2#L5) to be replaced with a custom filter writtten in Python.