### PR TITLE
[patch] Use 4.17.8 oc-mirror

### DIFF
--- a/image/cli-base/install/install-oc.sh
+++ b/image/cli-base/install/install-oc.sh
@@ -24,7 +24,7 @@ if [[ "$TARGET_PLATFORM" == "" ]]
 fi
 
 # Install OpenShift CLI (latest stable version)
-wget -q https://mirror.openshift.com/pub/openshift-v4/$TARGET_PLATFORM/clients/ocp/stable/openshift-client-linux.tar.gz
+wget -q https://mirror.openshift.com/pub/openshift-v4/$TARGET_PLATFORM/clients/ocp/4.17.8/openshift-client-linux.tar.gz
 tar -zxf openshift-client-linux.tar.gz
 mv oc /usr/local/bin/
 mv kubectl /usr/local/bin/
@@ -34,7 +34,7 @@ echo "oc version:"
 oc version
 
 # Install oc mirror plugin (latest stable version)
-wget -q https://mirror.openshift.com/pub/openshift-v4/$TARGET_PLATFORM/clients/ocp/stable/oc-mirror.tar.gz
+wget -q https://mirror.openshift.com/pub/openshift-v4/$TARGET_PLATFORM/clients/ocp/4.17.8/oc-mirror.tar.gz
 tar -zxf oc-mirror.tar.gz
 mv oc-mirror /usr/local/bin/
 chmod +x /usr/local/bin/oc-mirror

--- a/image/cli-base/install/install-oc.sh
+++ b/image/cli-base/install/install-oc.sh
@@ -24,6 +24,7 @@ if [[ "$TARGET_PLATFORM" == "" ]]
 fi
 
 # Install OpenShift CLI (latest stable version)
+# setting oc version to 4.17.8 due to issue: MASCORE-5777, Please validate again before April patch release
 wget -q https://mirror.openshift.com/pub/openshift-v4/$TARGET_PLATFORM/clients/ocp/4.17.8/openshift-client-linux.tar.gz
 tar -zxf openshift-client-linux.tar.gz
 mv oc /usr/local/bin/


### PR DESCRIPTION
## Description:
When we are using stable oc version that is currently `4.17.16`, It's failing in mirror job with below message
https://jsw.ibm.com/browse/MASCORE-5777
```
error: the manifest type *ocischema.DeserializedImageIndex is not supported
error: the manifest type *ocischema.DeserializedImageIndex is not supported
error: the manifest type *ocischema.DeserializedImageIndex is not supported
error: the manifest type *ocischema.DeserializedImageIndex is not supported
error: the manifest type *ocischema.DeserializedImageIndex is not supported
error: the manifest type *ocischema.DeserializedImageIndex is not supported
error: the manifest type *ocischema.DeserializedImageIndex is not supported
error: the manifest type *ocischema.DeserializedImageIndex is not supported
error: an error occurred during planning
```

Red Hat suggesting to use Older version of oc < `4.17.9`, So to resolve this issue, added oc version as `4.17.8` 

Testing:
Since 27th Feb, All the release fvts are using the oc version `4.17.8`