### PR TITLE
install sendmail

### DIFF
--- a/image/cli-base/Dockerfile
+++ b/image/cli-base/Dockerfile
@@ -9,7 +9,7 @@ ARG ARCHITECTURE
 USER root
 RUN dnf update -y --skip-broken --nobest &&\
     dnf upgrade -y --skip-broken --nobest &&\
-    dnf install nano jq sendmail sendmail-cf -y &&\
+    dnf install nano jq s-nail -y &&\
     dnf clean all
 
 # 2. Upgrade pip, install wheel, then install Python modules

--- a/image/cli-base/Dockerfile
+++ b/image/cli-base/Dockerfile
@@ -9,7 +9,7 @@ ARG ARCHITECTURE
 USER root
 RUN dnf update -y --skip-broken --nobest &&\
     dnf upgrade -y --skip-broken --nobest &&\
-    dnf install nano jq -y &&\
+    dnf install nano jq sendmail sendmail-cf -y &&\
     dnf clean all
 
 # 2. Upgrade pip, install wheel, then install Python modules


### PR DESCRIPTION
MASCORE-5733

Install `s-nail` package for sending emails, see https://wiki.archlinux.org/title/S-nail for further info. Attempts to install the perhaps more commonly known `sendmail` fail; even after configuring EPEL repository the package cannot be found. I am not sure what the root cause is, but may be a quick of UBI images. In any case, `s-nail` should suffice.
