### PR TITLE
[patch] Update rosa cli path and python packages to latest patch

### DIFF
--- a/image/cli-base/install/install-rosa.sh
+++ b/image/cli-base/install/install-rosa.sh
@@ -25,7 +25,7 @@ if [[ "$TARGET_PLATFORM" == "s390x" ]]; then
   exit 0
 fi
 
-wget -q https://mirror.openshift.com/pub/openshift-v4/clients/rosa/latest/rosa-linux.tar.gz
+wget -q https://mirror.openshift.com/pub/cgw/rosa/latest/rosa-linux.tar.gz
 tar -xzf rosa-linux.tar.gz
 mv rosa /usr/local/bin/
 chmod +x /usr/local/bin/rosa

--- a/image/cli-base/install/requirements.txt
+++ b/image/cli-base/install/requirements.txt
@@ -1,5 +1,5 @@
 junit_xml==1.9
-pymongo==4.15.4
+pymongo==4.15.5
 xmljson==0.2.1
 ansible==13.0.0
 kubernetes==34.1.0

--- a/image/cli-base/install/requirements.txt
+++ b/image/cli-base/install/requirements.txt
@@ -4,11 +4,11 @@ xmljson==0.2.1
 ansible==13.0.0
 kubernetes==34.1.0
 openshift==0.13.2
-jmespath==1.0.1
+jmespath==1.1.0
 click==8.3.1
 prettytable==3.17.0
 jinja-cli==1.2.2
-jinjanator==25.3.0
+jinjanator==25.3.1
 slack-sdk==3.39.0
 jira==3.10.5
-boto3==1.41.2
+boto3==1.41.5


### PR DESCRIPTION
I have updated the rosa cli download path to `https://mirror.openshift.com/pub/cgw/rosa/latest/rosa-linux.tar.gz` because the other path only provded version `1.2.53` but we need the latest `1.2.61` for IDMS support.

In `requirements.txt`:
- Update to latest patch
  - pymongo
  - jinjanator
  - boto3
- Update to latest minor
  - jmespath (now supports python 3.12 which we are using)