### PR TITLE
[minor] Add auto-completion for aws, oc, kubectl, helm, argocd

### DIFF
--- a/image/cli-base/Dockerfile
+++ b/image/cli-base/Dockerfile
@@ -9,7 +9,7 @@ ARG ARCHITECTURE
 USER root
 RUN dnf update -y --skip-broken --nobest &&\
     dnf upgrade -y --skip-broken --nobest &&\
-    dnf install nano jq libxcrypt-compat cpio -y &&\
+    dnf install nano jq libxcrypt-compat cpio bash-completion -y &&\
     dnf clean all
 
 # 2. Upgrade pip, install wheel, then install Python modules
@@ -51,7 +51,8 @@ RUN bash /tmp/remediate.sh
 
 # 6. Cleanup
 RUN rm -rf /tmp/*
-# 11. Setup working environment
+
+# 7. Setup working environment
 WORKDIR /mascli
 ENTRYPOINT ["/tini", "--"]
 CMD bash

--- a/image/cli-base/install/install-argocd.sh
+++ b/image/cli-base/install/install-argocd.sh
@@ -28,3 +28,6 @@ curl -sSL -o argocd-linux-${TARGET_PLATFORM} https://github.com/argoproj/argo-cd
 
 echo "ArgoCD version:"
 argocd version --client
+
+# Enable autocompletion for helm
+argocd completion bash > /etc/bash_completion.d/argocd_completion

--- a/image/cli-base/install/install-aws.sh
+++ b/image/cli-base/install/install-aws.sh
@@ -45,3 +45,6 @@ rm -rf aws
 rm  awscliv2.zip
 echo "AWS version:"
 aws --version
+
+# Set up bash completion for aws
+ln -s /usr/local/bin/aws_completer /etc/bash_completion.d/aws_completion

--- a/image/cli-base/install/install-helm.sh
+++ b/image/cli-base/install/install-helm.sh
@@ -39,3 +39,6 @@ else
 fi
 echo "Helm version:"
 helm version
+
+# Enable autocompletion for helm
+helm completion bash > /etc/bash_completion.d/helm_completion

--- a/image/cli-base/install/install-oc.sh
+++ b/image/cli-base/install/install-oc.sh
@@ -9,7 +9,7 @@ do
     --target-platform)
     TARGET_PLATFORM="$2"
     ;;
-    
+
     *)
     # unknown option, use as additional params directly to docker
     EXTRA_PARAMS="$EXTRA_PARAMS $key $2"
@@ -41,3 +41,7 @@ mv oc-mirror /usr/local/bin/
 chmod +x /usr/local/bin/oc-mirror
 rm -f oc-mirror.tar.gz
 rm -f /opt/app-root/src/.oc-mirror.log
+
+# Enable bash completion for oc and kubectl
+oc completion bash > /etc/bash_completion.d/oc_completion
+kubectl completion bash > /etc/bash_completion.d/kubectl_completion


### PR DESCRIPTION
See https://github.com/ibm-mas/cli/issues/1916 for details

```
# Kubernetes
kubectl get pod <TAB><TAB>
kubectl get deployment <TAB><TAB>

# OpenShift
oc get route <TAB><TAB>

# Helm
helm upgrade --install <TAB><TAB>

# ArgoCD
argocd app list --project <TAB><TAB>

# AWS CLI
aws eks describe-cluster --name <TAB><TAB>
```